### PR TITLE
fix: update package version for semantic-release-helm

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.11.5",
-    "@liatrio/semantic-release-helm": "^2.0.0",
+    "@liatrio/semantic-release-helm": "^2.1.0",
     "@semantic-release/git": "^10.0.1",
     "@svgr/webpack": "^5.4.0",
     "@testing-library/react": "^11.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,10 +2571,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@liatrio/semantic-release-helm@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@liatrio/semantic-release-helm/-/semantic-release-helm-2.0.0.tgz#d1f04b1843eb45bea6fb6b7403f2ebbac6fc08eb"
-  integrity sha512-BKP18j2NgdT7jfmM+cUTWPI2BCcUIepbcJE8ZZhVWLdIgDMTBGD1HrlIwMwChhizAD+IWIVjcGgTfpCVmopc+w==
+"@liatrio/semantic-release-helm@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@liatrio/semantic-release-helm/-/semantic-release-helm-2.1.0.tgz#efce0bfabfbddda74bdac5f9d383ea42d2cf24af"
+  integrity sha512-ZPBaigAIPjsRy/KKtoDHiX3AcOsk3YkY/jkwgNetPF/LLKtjWttymBh8JklJFpGG8SJIPhAqlWnd10Vo5EsvcA==
   dependencies:
     "@aws-sdk/client-s3" "^3.48.0"
     "@aws-sdk/client-sts" "^3.48.0"


### PR DESCRIPTION
roll the package.json and yarn.lock to require at least 2.1.0 of semantic-release-helm