### PR TITLE
fix: update post-release workflow to correct helm deploy steps

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -71,6 +71,6 @@ jobs:
         run: |
           helm repo add envelope-game https://liatrio.github.io/envelope-game
           helm repo update
-          helm install envelope-game envelope-game/envelope-game -n ${{ env.NAMESPACE }}
+          helm upgrade --install envelope-game envelope-game/envelope-game -n ${{ env.NAMESPACE }}
         env:
           image_name: ${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.tag }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -74,4 +74,4 @@ jobs:
           repo: https://liatrio.github.io/envelope-game
           token: '${{ github.token }}'
           values: |
-            image.name: ${{ env.IMAGE_NAME }}:${{ docker.outputs.tag }}
+            image.name: ${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.tag }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -40,8 +40,6 @@ jobs:
           username: ${{ secrets.CR_USER }}
           password: ${{ secrets.CR_PAT }}
 
-
-
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -54,7 +52,7 @@ jobs:
     needs: docker
 
     name: Helm Deploy Dev
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, caf, prod, terraform]
     environment: envelope-game-dev
 
     steps:
@@ -65,13 +63,14 @@ jobs:
           cluster-name: ${{ env.CLUSTER_NAME }}
           resource-group: ${{ env.CLUSTER_RESOURCE_GROUP }}
 
-      - name: '⎈ Deploy'
-        uses: 'deliverybot/helm@v1'
-        with:
-          release: envelope-game
-          namespace: ${{ env.NAMESPACE }}
-          chart: envelope-game
-          repo: https://liatrio.github.io/envelope-game
-          token: '${{ github.token }}'
-          values: |
-            image.name: ${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.tag }}
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        id: install
+
+      - name: 'Helm Deploy'
+        run: |
+          helm repo add envelope-game https://liatrio.github.io/envelope-game
+          helm repo update
+          helm install envelope-game envelope-game/envelope-game -n ${{ env.NAMESPACE }}
+        env:
+          image_name: ${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.tag }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -52,7 +52,7 @@ jobs:
     needs: docker
 
     name: Helm Deploy Dev
-    runs-on: [self-hosted, caf, prod, terraform]
+    runs-on: [self-hosted, caf]
     environment: envelope-game-dev
 
     steps:
@@ -71,6 +71,4 @@ jobs:
         run: |
           helm repo add envelope-game https://liatrio.github.io/envelope-game
           helm repo update
-          helm upgrade --install envelope-game envelope-game/envelope-game -n ${{ env.NAMESPACE }}
-        env:
-          image_name: ${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.tag }}
+          helm upgrade --install envelope-game envelope-game/envelope-game --set image.name=${{ env.IMAGE_NAME }}:${{ needs.docker.outputs.tag }} -n ${{ env.NAMESPACE }}


### PR DESCRIPTION
Uses self-hosted runners Removes deliverybot/helm action
Adds helm tool installation action
Adds helm deploy script step