### PR TITLE
chore: ingress api version bump

### DIFF
--- a/charts/envelope-game/templates/ingress.yaml
+++ b/charts/envelope-game/templates/ingress.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "envelope-game.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: extensions/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Updating ingress api version as the old version is not supported by kubernetes version >=1.22
